### PR TITLE
Skip devices without serial number in list_devices

### DIFF
--- a/ft232/libftdi.py
+++ b/ft232/libftdi.py
@@ -95,7 +95,7 @@ def list_devices():
                     serial = h.getString(dev.iSerialNumber, 20)
                     desc = h.getString(dev.iProduct, 100)
                     ret.append((serial, desc))
-                except usb.USBError:
+                except:
                     pass
     return ret
 


### PR DESCRIPTION
Underlying usb code may raise exceptions other than
just usb.USBError, which was only exception explicitly
caught.